### PR TITLE
Remove include "asm/system.h"

### DIFF
--- a/template.c
+++ b/template.c
@@ -13,7 +13,7 @@
 #include<asm/current.h>
 #include<linux/sched.h>
 #include<linux/syscalls.h>
-#include<asm/system.h>
+/*#include<asm/system.h>*/
 #include<linux/fs.h>
 #include<linux/keyboard.h>
 #include<linux/input.h>


### PR DESCRIPTION
## Hello!

First of all, great projects (not only this one, but all of your kernel related projects), respect 👏🏻. 

Changes in this Pull Request:
- Remove include "asm/system.h" in `template.c`
